### PR TITLE
for now, include SMP/E always in the archive so PTFs can be applied o…

### DIFF
--- a/bin/zbrewarchive
+++ b/bin/zbrewarchive
@@ -26,5 +26,5 @@ fi
 ussname=$(echo $1 | tr '[:upper:]' '[:lower:]');
 zosname=$(echo $1 | tr '[:lower:]' '[:upper:]');
 
-dzip -s250M "${ZBREW_TMP}/${ussname}.dzp" "${ZBREW_SRC_HLQ}${zosname}.*"
+dzip -s500M "${ZBREW_TMP}/${ussname}.dzp" "${ZBREW_SRC_HLQ}${zosname}*.*" 
 exit $rc


### PR DESCRIPTION
…n the target system. Consider an option in the future to not archive the SMP/E stuff