### PR TITLE
for now, include SMP/E always in the archive so PTFs can be applied o…

### DIFF
--- a/bin/zbrew
+++ b/bin/zbrew
@@ -346,7 +346,7 @@ deconfigure() {
 				fi
 			fi
 		done
-		drm -f "${ZBREW_TGT_HLQ}${zosname}.*"
+		drm -f "${ZBREW_TGT_HLQ}${zosname}*.*"
 	fi
 	zbrewlog "deconfigure RC: $?"
 	return $?


### PR DESCRIPTION
…n the target system. Consider an option in the future to not archive the SMP/E stuff